### PR TITLE
Add CORS preflight handler, enlarge upload file size and add docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+  openai-api-gateway:
+    build: .
+    container_name: openai-api-gateway
+    ports:
+      - 80:40000
+    environment:
+      - GATEWAY_API_KEY=super_secret_api_key                               # Required
+      - OPENAI_API_KEY=$OPENAI_API_KEY                                     # Required
+      - OPENAI_API_HOST=https://api.openai.com                             # Optional
+      - RATE_LIMIT=20r/m                                                   # Optional
+    restart: unless-stopped

--- a/gateway-nginx.conf
+++ b/gateway-nginx.conf
@@ -8,14 +8,26 @@ server {
     # Configure Nginx to listen on port 80
     listen 80;
 
-    # If the client is not authorized ($http_authorization not equals to "Bearer ${GATEWAY_API_KEY}"), return an HTTP 401 Unauthorized status code
-    if ($http_authorization != "Bearer ${GATEWAY_API_KEY}") {
-        return 401;
-    }
-
     # "location /" defines how to respond to requests for URLs beginning with / 
     location / {
         
+        # CORS handler
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Credentials' 'true';
+            add_header 'Access-Control-Allow-Methods' '*';
+            add_header 'Access-Control-Allow-Headers' '*';
+            add_header 'Access-Control-Max-Age' 86400;
+            add_header 'Content-Type' 'text/plain charset=UTF-8';
+            add_header 'Content-Length' 0;
+            return 204; break;
+        }
+
+        # If the client is not authorized ($http_authorization not equals to "Bearer ${GATEWAY_API_KEY}"), return an HTTP 401 Unauthorized status code
+        if ($http_authorization != "Bearer ${GATEWAY_API_KEY}") {
+            return 401;
+        }
+
         # Set the proxy server to be used for requests
         proxy_pass ${OPENAI_API_HOST};
 

--- a/gateway-nginx.conf
+++ b/gateway-nginx.conf
@@ -2,6 +2,9 @@
 # Define a shared memory zone "api" to store states of limiting requests. The maximum size for this zone is 10MB. RATE_LIMIT sets the rate of requests
 limit_req_zone $binary_remote_addr zone=api:10m rate=${RATE_LIMIT};
 
+# OpenAi API limitation is 25mb
+client_max_body_size 25m;
+
 # Start server configuration
 server {
 


### PR DESCRIPTION
First of all -- thank you for this usefull reverse proxy. I have made a few modifications to your project. Please review my code and let me know if you have any feedback or suggestions. Thank you!

# Problems addressed
## CORS
API gateway functions properly, but when using it in e.g. browser pluggins (or obsidian) it breaks on CORS preflight checks:
```
Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
```

## Nginx file size default limitations 
By default, Nginx has a file size limit of 1mb, whereas the OpenAI API allows file sizes up to 25mb. This becomes problematic when using the Whisper API for tasks such as audio transcription, as the current limit is quickly reached.

# Changes added
- add CORS handlers 
- expande file size limit to 25mb
- include docker-compose.yaml file